### PR TITLE
Fetch a list of tags instead of releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,9 +53,9 @@ outputs:
     value: ${{ steps.set-output.outputs.docker_image_full_name }}
 
 branding:
-  icon: 'layers'  
+  icon: 'layers'
   color: 'blue'
-  
+
 runs:
   using: "composite"
   steps:
@@ -101,13 +101,13 @@ runs:
       run: |
         # Get the latest version
         if [[ "${{ inputs.rasa_sdk_version }}" == "latest" ]]; then
-          LATEST_RASA_SDK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/releases" | jq -r .[].tag_name | grep -v refs | sort -Vr | head -n1)
+          LATEST_RASA_SDK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r .[].name | grep -v refs | sort -Vr | head -n1)
           echo "::set-env name=RASA_SDK_VERSION::${LATEST_RASA_SDK_VERSION}"
         else
           # Validate Rasa SDK version
-          CHECK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/releases" | jq -r '.[] | select(.tag_name=="${{ inputs.rasa_sdk_version }}") | .tag_name')
+          CHECK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r '.[] | select(.name=="${{ inputs.rasa_sdk_version }}") | .name')
           if [[ "$CHECK_VERSION" != "${{ inputs.rasa_sdk_version }}" ]]; then
-            echo "::error::Rasa SDK in ${{ inputs.rasa_sdk_version }} version doesn't exist. Check if the given Rasa SDK version is valid, https://github.com/RasaHQ/rasa-sdk/releases" && exit 1
+            echo "::error::Rasa SDK in ${{ inputs.rasa_sdk_version }} version doesn't exist. Check if the given Rasa SDK version is valid, https://github.com/RasaHQ/rasa-sdk/tags" && exit 1
           fi
           echo "::set-env name=RASA_SDK_VERSION::${{ inputs.rasa_sdk_version }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -99,16 +99,16 @@ runs:
     - name: Set the Rasa SDK version
       shell: bash
       run: |
+        DOCKERHUB_TAGS_URL="https://registry.hub.docker.com/v2/repositories/rasa/rasa-sdk/tags?page_size=10000"
         # Get the latest version
         if [[ "${{ inputs.rasa_sdk_version }}" == "latest" ]]; then
-          LATEST_RASA_SDK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r .[].name | grep -v refs | sort -Vr | head -n1)
-          echo "action_state=yellow"
+          LATEST_RASA_SDK_VERSION=$(curl -s ${DOCKERHUB_TAGS_URL} | jq -r '.results[].name' | grep -vE 'refs|aws|latest' | sort -Vr | head -n1)
           echo "RASA_SDK_VERSION=${LATEST_RASA_SDK_VERSION}" >> $GITHUB_ENV
         else
           # Validate Rasa SDK version
-          CHECK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r '.[] | select(.name=="${{ inputs.rasa_sdk_version }}") | .name')
+          CHECK_VERSION=$(curl --silent ${DOCKERHUB_TAGS_URL} | jq -r '.results[] | select(.name=="${{ inputs.rasa_sdk_version }}") | .name')
           if [[ "$CHECK_VERSION" != "${{ inputs.rasa_sdk_version }}" ]]; then
-            echo "::error::Rasa SDK in ${{ inputs.rasa_sdk_version }} version doesn't exist. Check if the given Rasa SDK version is valid, https://github.com/RasaHQ/rasa-sdk/tags" && exit 1
+            echo "::error::Rasa SDK in ${{ inputs.rasa_sdk_version }} version doesn't exist. Check if the given Rasa SDK version is valid, https://hub.docker.com/r/rasa/rasa-sdk/tags" && exit 1
           fi
           echo "RASA_SDK_VERSION=${{ inputs.rasa_sdk_version }}" >> $GITHUB_ENV
         fi

--- a/action.yml
+++ b/action.yml
@@ -64,13 +64,13 @@ runs:
       run: |-
         # Set Dockerfile
         if [[ "${{ inputs.dockerfile }}" == "" ]]; then
-          echo "::set-env name=DOCKERFILE::${{ github.action_path }}/default_files/Dockerfile"
+          echo "DOCKERFILE=${{ github.action_path }}/default_files/Dockerfile" >> $GITHUB_ENV
         else
-          echo "::set-env name=DOCKERFILE::${{ inputs.dockerfile }}"
+          echo "DOCKERFILE=${{ inputs.dockerfile }}" >> $GITHUB_ENV
         fi
 
         # Set DOCKER_IMAGE_FULL_NAME
-        echo "::set-env name=DOCKER_IMAGE_FULL_NAME::${{ inputs.docker_registry }}/${{ inputs.docker_image_name }}:${{ inputs.docker_image_tag }}"
+        echo "DOCKER_IMAGE_FULL_NAME=${{ inputs.docker_registry }}/${{ inputs.docker_image_name }}:${{ inputs.docker_image_tag }}" >> $GITHUB_ENV
 
     - name: Copy files
       shell: bash
@@ -102,14 +102,15 @@ runs:
         # Get the latest version
         if [[ "${{ inputs.rasa_sdk_version }}" == "latest" ]]; then
           LATEST_RASA_SDK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r .[].name | grep -v refs | sort -Vr | head -n1)
-          echo "::set-env name=RASA_SDK_VERSION::${LATEST_RASA_SDK_VERSION}"
+          echo "action_state=yellow"
+          echo "RASA_SDK_VERSION=${LATEST_RASA_SDK_VERSION}" >> $GITHUB_ENV
         else
           # Validate Rasa SDK version
           CHECK_VERSION=$(curl --silent "https://api.github.com/repos/RasaHQ/rasa-sdk/tags" | jq -r '.[] | select(.name=="${{ inputs.rasa_sdk_version }}") | .name')
           if [[ "$CHECK_VERSION" != "${{ inputs.rasa_sdk_version }}" ]]; then
             echo "::error::Rasa SDK in ${{ inputs.rasa_sdk_version }} version doesn't exist. Check if the given Rasa SDK version is valid, https://github.com/RasaHQ/rasa-sdk/tags" && exit 1
           fi
-          echo "::set-env name=RASA_SDK_VERSION::${{ inputs.rasa_sdk_version }}"
+          echo "RASA_SDK_VERSION=${{ inputs.rasa_sdk_version }}" >> $GITHUB_ENV
         fi
 
     - name: Docker login

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,6 @@ runs:
         echo "    DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}"
         echo "    DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}"
         echo "    RASA_SDK_VERSION: ${{ env.RASA_SDK_VERSION }}"
-        echo "    REQUIREMENTS_FILE: ${{ env.REQUIREMENTS_FILE }}"
         echo ""
         echo "  Docker build extra arguments: ${{ inputs.docker_build_args}}"
         echo ""
@@ -142,7 +141,6 @@ runs:
           --build-arg GITHUB_REF="$GITHUB_REF" \
           --build-arg DOCKER_IMAGE_NAME="${{ inputs.docker_image_name }}" \
           --build-arg RASA_SDK_VERSION="${{ env.RASA_SDK_VERSION }}" \
-          --build-arg REQUIREMENTS_FILE="${{ env.REQUIREMENTS_FILE }}" \
           --build-arg DOCKER_IMAGE_TAG="${{ inputs.docker_image_tag }}" ${{ inputs.docker_build_args }}\
           -f ${{ env.DOCKERFILE }} ${{ github.workspace }}
       shell: bash


### PR DESCRIPTION
- In order to validate Rasa SDK version, we should fetch a list of tags from Docker Hub instead of releases from GitHub
- Remove useless env variable - `REQUIREMENTS_FILE`
- Don't use the `set-env` workflow command - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/